### PR TITLE
Removed tslint related errors

### DIFF
--- a/jqwidgets-ts/angular_jqxtreegrid.ts
+++ b/jqwidgets-ts/angular_jqxtreegrid.ts
@@ -17,7 +17,7 @@ import '../jqwidgets/jqxnumberinput.js';
 import '../jqwidgets/jqxdropdownlist.js';
 import '../jqwidgets/jqxdatatable.js';
 import '../jqwidgets/jqxtreegrid.js';
-import { Component, Input, Output, EventEmitter, ElementRef, forwardRef, OnChanges, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
 declare let JQXLite: any;
 
 @Component({

--- a/jqwidgets-ts/jqwidgets.d.ts
+++ b/jqwidgets-ts/jqwidgets.d.ts
@@ -10,7 +10,7 @@ interface JQueryStatic {
 }
 
 declare var generatedata: any;
-declare var jqx;
+declare var jqx: any;
 
 declare module jqwidgets {
     export function createInstance(selector: string, widgetName: string, params?: any): any;


### PR DESCRIPTION
Removed typescript compiler errors. Even if node_modules directory is excluded, typescript compiler still complains.

We are in a CI environment and our build constantly fails because of this error.
For now, we have to manually update the typescript files in node_modules directory which is painful.
We also have commercial license to use JQWidgets and please consider this pull request.

Ref: https://github.com/Microsoft/TypeScript/wiki/FAQ#why-is-a-file-in-the-exclude-list-still-picked-up-by-the-compiler