### PR TITLE
Provide item.value instead of item.label to onChangeCallback

### DIFF
--- a/jqwidgets-ts/angular_jqxcombobox.ts
+++ b/jqwidgets-ts/angular_jqxcombobox.ts
@@ -705,7 +705,7 @@ export class jqxComboBoxComponent implements ControlValueAccessor, OnChanges
       this.host.on('bindingComplete', (eventData: any) => { this.onBindingComplete.emit(eventData); });
       this.host.on('checkChange', (eventData: any) => { this.onCheckChange.emit(eventData); });
       this.host.on('close', (eventData: any) => { this.onClose.emit(eventData); });
-      this.host.on('change', (eventData: any) => { this.onChange.emit(eventData); if(eventData.args) if(eventData.args.item !== null) this.onChangeCallback(eventData.args.item.label); });
+      this.host.on('change', (eventData: any) => { this.onChange.emit(eventData); if(eventData.args) if(eventData.args.item !== null) this.onChangeCallback(eventData.args.item.value); });
       this.host.on('open', (eventData: any) => { this.onOpen.emit(eventData); });
       this.host.on('select', (eventData: any) => { this.onSelect.emit(eventData); });
       this.host.on('unselect', (eventData: any) => { this.onUnselect.emit(eventData); });


### PR DESCRIPTION
Allow correct binding in Angular Forms without custom handling of selected value

The current implementation - when used e.g. with ngrx-forms - leads to publishing of the display value (item.label) rather than the real value (item.value) which prevents seamless usage of this widget in Angular apps.

This simple PR fixes this behavior.